### PR TITLE
Fix UnicodeDecodeError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,13 +28,14 @@ Links
 
 """
 import re
+import io
 from setuptools import setup, find_packages
 
 from cmds import cmdclass
 
 
 # detect the current version.
-with open('hangulize/__init__.py', encoding='utf-8') as f:
+with io.open('hangulize/__init__.py', encoding='utf-8') as f:
     version = re.search(r'__version__\s*=\s*\'(.+?)\'', f.read()).group(1)
 assert version
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ from cmds import cmdclass
 
 
 # detect the current version.
-with open('hangulize/__init__.py') as f:
+with open('hangulize/__init__.py', encoding='utf-8') as f:
     version = re.search(r'__version__\s*=\s*\'(.+?)\'', f.read()).group(1)
 assert version
 


### PR DESCRIPTION
```
pip install hangulize
...
UnicodeDecodeError: 'cp949' codec can't decode bytes in position : illegal multibyte sequence
```

Windows 환경에서 발생할 수 있는 위 에러를 해결하기 위해서 encoding='utf-8' 지정이 필요할 수 있습니다.